### PR TITLE
fix: repair unit test suite

### DIFF
--- a/commit-msg.py
+++ b/commit-msg.py
@@ -17,6 +17,11 @@ REMOTE_PATH = (
 )
 
 COMMIT_REGEX = re.compile(r"^([a-z]+)(?:\(([a-z|_|\-|\/]+)\))?:(.*)$")
+CONFIG_REGEX = re.compile(
+    r"([ \t]*TYPES:\s+(?:set|Set)\[str\]\s*=\s*(?:\{[^}]*\}|set\(\))\n"
+    r"[ \t]*SCOPES:\s+(?:set|Set)\[str\]\s*=\s*(?:\{[^}]*\}|set\(\))\n"
+    r"[ \t]*SCOPE_REQUIRED:\s+bool\s*=\s*(?:True|False))"
+)
 
 ## User Config
 ## Don't remove type annotations
@@ -163,9 +168,8 @@ def versions_compatible(current_contents: str, source: str) -> bool:
 
 def swap_out_config(current_contents: str, source: str) -> str:
     debug("PRESERVING CONFIGURATION LINES")
-    config_ptn = r"(TYPES: +set\[str\] += +{[^}]+}\n+SCOPES: +set\[str\] += +{[^}]*}\n+SCOPE_REQUIRED: +bool += +True|False)"
-    match1 = re.search(config_ptn, current_contents)
-    match2 = re.search(config_ptn, source)
+    match1 = re.search(CONFIG_REGEX, current_contents)
+    match2 = re.search(CONFIG_REGEX, source)
     if match1 is not None and match2 is not None:
         (current_config,) = match1.groups()
         (source_config,) = match2.groups()
@@ -235,7 +239,7 @@ def install(hook_path: Path) -> int:
             + "}"
         )
 
-    scopes_ptn = r"SCOPES: +Set\[str\] += +({.+})"
+    scopes_ptn = r"SCOPES: +(set|Set)\[str\] += +(\{[^}]*\}|set\(\))"
 
     source = re.sub(scopes_ptn, scopes_str, source)
 
@@ -327,7 +331,7 @@ def test_validate() -> None:
 def test_git_root() -> None:
     gr = git_root()
 
-    assert gr.exists() and gr.name == "commit-msg.py"
+    assert gr.exists() and (gr / "commit-msg.py").exists()
 
 
 def test_versions_compatible() -> None:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-python_files = commit-msg.py

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+python_files = commit-msg.py


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- make the git-root test independent of checkout directory name
- make config preservation handle current `set[str]` config blocks with indentation and update install-time scope replacement
- remove the pytest config file per follow-up request

## Testing
- `python3 -m pytest -q commit-msg.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aeb9f2ff-d470-4aa8-9a0c-e7ce96fb0bfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aeb9f2ff-d470-4aa8-9a0c-e7ce96fb0bfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

