### PR TITLE
fix: handle install download failure

### DIFF
--- a/commit-msg.py
+++ b/commit-msg.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from subprocess import CalledProcessError, run
 from typing import Literal
 
-VERSION = "0.3.0"
+VERSION = "0.3.1"
 REMOTE_PATH = (
     "https://raw.githubusercontent.com/bpshaver/commit-msg.py/main/commit-msg.py"
 )
@@ -223,6 +223,7 @@ def install(hook_path: Path) -> int:
         source = get_source()
     except CalledProcessError:
         setup_error("error downloading commit-msg.py. Install manually.")
+        return 1
 
     debug("INFERRING EXISTING SCOPES")
     scopes = existing_scopes()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- return a failure status from `install()` when downloading the hook source fails
- bump `VERSION` from `0.3.0` to `0.3.1` as a patch release

## Testing
- `python3 -m py_compile commit-msg.py`
- direct probe verifies `install()` returns `1` after a simulated `CalledProcessError` from `get_source()`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aeb9f2ff-d470-4aa8-9a0c-e7ce96fb0bfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aeb9f2ff-d470-4aa8-9a0c-e7ce96fb0bfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

