### PR TITLE
fix: compare versions semantically

### DIFF
--- a/commit-msg.py
+++ b/commit-msg.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from subprocess import CalledProcessError, run
 from typing import Literal
 
-VERSION = "0.3.0"
+VERSION = "0.3.1"
 REMOTE_PATH = (
     "https://raw.githubusercontent.com/bpshaver/commit-msg.py/main/commit-msg.py"
 )
@@ -147,16 +147,16 @@ def versions_compatible(current_contents: str, source: str) -> bool:
 
         old_version_str, old_major, old_minor, old_patch = old_version.groups()
         new_version_str, new_major, new_minor, new_patch = new_version.groups()
+        old_version_tuple = tuple(int(part) for part in (old_major, old_minor, old_patch))
+        new_version_tuple = tuple(int(part) for part in (new_major, new_minor, new_patch))
         if new_version_str == old_version_str:
             setup_error("already up-to-date.")
             return False
-        elif new_major == old_major and (
-            new_minor > old_minor or (new_minor == old_minor and new_patch > old_patch)
-        ):
+        elif new_major == old_major and new_version_tuple > old_version_tuple:
             return True
         else:
             setup_error(
-                f"new version {old_version_str} not compatible with existing version {new_version_str}. Update manually"
+                f"new version {new_version_str} not compatible with existing version {old_version_str}. Update manually"
             )
             return False
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- compare parsed semantic version components as integers instead of strings
- correct the incompatible-version error message to report new and existing versions in the right positions
- bump `VERSION` from `0.3.0` to `0.3.1` as a patch release

## Testing
- `python3 -m py_compile commit-msg.py`
- direct probes cover `1.9.0` -> `1.10.0`, downgrade, major-version mismatch, and same-version cases
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aeb9f2ff-d470-4aa8-9a0c-e7ce96fb0bfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aeb9f2ff-d470-4aa8-9a0c-e7ce96fb0bfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

