### PR TITLE
fix: infer scopes from commit subjects

### DIFF
--- a/commit-msg.py
+++ b/commit-msg.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from subprocess import CalledProcessError, run
 from typing import Literal
 
-VERSION = "0.3.0"
+VERSION = "0.3.1"
 REMOTE_PATH = (
     "https://raw.githubusercontent.com/bpshaver/commit-msg.py/main/commit-msg.py"
 )
@@ -207,10 +207,13 @@ def update(hook_path: Path) -> int:
 def existing_scopes() -> set[str]:
     scopes = set()
     result = run(
-        "git log --no-merges --oneline".split(), capture_output=True, check=True
+        ["git", "log", "--no-merges", "--format=%s"],
+        capture_output=True,
+        check=True,
+        text=True,
     )
-    for line in result.stdout.decode().split("\n"):
-        match = re.match(r"[a-z|0-9]{7} [a-z]+\(([a-z|_|\-|\/]+)\): ", line)
+    for line in result.stdout.splitlines():
+        match = re.match(r"[a-z]+\(([a-z|_|\-|\/]+)\): ", line)
         if match:
             scopes.add(match.group(1))
     return scopes


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- read commit subjects directly with `git log --format=%s` instead of parsing `--oneline` hash prefixes
- update stdout handling to use text mode and `splitlines()`
- bump `VERSION` from `0.3.0` to `0.3.1` as a patch release

## Testing
- `python3 -m py_compile commit-msg.py`
- direct probe verifies scoped subjects are inferred without relying on hash abbreviation length
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aeb9f2ff-d470-4aa8-9a0c-e7ce96fb0bfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aeb9f2ff-d470-4aa8-9a0c-e7ce96fb0bfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

