### PR TITLE
feat: support expanded commit messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ The script is meant to be edited.
 - Customize the constants `TYPES`, `SCOPES`, and `SCOPE_REQUIRED` according to your project's needs.
 - If Git fails to run the script using a Python interpreter, you may need to adjust the shebang.
 
+## Unit tests
+
+Run the inline unit tests with:
+
+`python3 -m pytest -q commit-msg.py`
+
 ## Tips
 
 - To find the short list of your already used types and scopes (assuming your Git log is compliant with

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The script is meant to be edited.
 
 Run the inline unit tests with:
 
-`python3 -m pytest -q commit-msg.py`
+`pytest commit-msg.py`
 
 ## Tips
 

--- a/commit-msg.py
+++ b/commit-msg.py
@@ -11,18 +11,24 @@ from pathlib import Path
 from subprocess import CalledProcessError, run
 from typing import Literal
 
-VERSION = "0.3.0"
+VERSION = "0.4.0"
 REMOTE_PATH = (
     "https://raw.githubusercontent.com/bpshaver/commit-msg.py/main/commit-msg.py"
 )
 
-COMMIT_REGEX = re.compile(r"^([a-z]+)(?:\(([a-z|_|\-|\/]+)\))?:(.*)$")
+COMMIT_REGEX = re.compile(r"^([a-z]+)(?:\(([a-z|_|\-|\/]+)\))?!?:(.*)$")
+CONFIG_REGEX = re.compile(
+    r"([ \t]*TYPES:\s+set\[str\]\s*=\s*\{[^}]+\}\n"
+    r"[ \t]*SCOPES:\s+set\[str\]\s*=\s*\{[^}]*\}\n"
+    r"[ \t]*SCOPE_REQUIRED:\s+bool\s*=\s*(?:True|False))"
+)
 
 ## User Config
 ## Don't remove type annotations
 
 TYPES: set[str] = {
     "fix",
+    "hotfix",
     "feat",
     "docs",
     "style",
@@ -78,7 +84,8 @@ def setup_error(msg: str) -> None:
 def validate(
     msg: str, types: set[str], scopes: set[str], scope_required: bool
 ) -> validation_result:
-    match = re.match(COMMIT_REGEX, msg)
+    subject = msg.splitlines()[0] if msg else ""
+    match = re.match(COMMIT_REGEX, subject)
     if not match:
         return "failing"
     type, scope, msg = match.groups()
@@ -163,9 +170,8 @@ def versions_compatible(current_contents: str, source: str) -> bool:
 
 def swap_out_config(current_contents: str, source: str) -> str:
     debug("PRESERVING CONFIGURATION LINES")
-    config_ptn = r"(TYPES: +set\[str\] += +{[^}]+}\n+SCOPES: +set\[str\] += +{[^}]*}\n+SCOPE_REQUIRED: +bool += +True|False)"
-    match1 = re.search(config_ptn, current_contents)
-    match2 = re.search(config_ptn, source)
+    match1 = re.search(CONFIG_REGEX, current_contents)
+    match2 = re.search(CONFIG_REGEX, source)
     if match1 is not None and match2 is not None:
         (current_config,) = match1.groups()
         (source_config,) = match2.groups()
@@ -307,6 +313,13 @@ if __name__ == "__main__":
 # Unit Tests
 def test_validate() -> None:
     assert validate("fix: foobar", {"fix"}, set(), False) == "passing"
+    assert validate("hotfix: foobar", {"hotfix"}, set(), False) == "passing"
+    assert validate("feat!: foobar", {"feat"}, set(), False) == "passing"
+    assert validate("feat(api)!: foobar", {"feat"}, {"api"}, False) == "passing"
+    assert (
+        validate("feat: foobar\n\nLonger body text.", {"feat"}, set(), False)
+        == "passing"
+    )
     assert validate("fix: foobar", {"feat"}, set(), False) == "type_failing"
     assert validate("feat: foobar", {"feat"}, set(), True) == "scope_required"
     assert validate("feat(foobar): foobar", {"feat"}, {"api"}, False) == "scope_failing"
@@ -327,7 +340,7 @@ def test_validate() -> None:
 def test_git_root() -> None:
     gr = git_root()
 
-    assert gr.exists() and gr.name == "commit-msg.py"
+    assert gr.exists() and (gr / "commit-msg.py").exists()
 
 
 def test_versions_compatible() -> None:
@@ -352,7 +365,7 @@ def test_swap_out_configs() -> None:
     """)
     new = fix("""
     test>new stuff...         
-    test>TYPES: set[str] = {"fix", "feat", "docs", "style", "refactor", "test", "chore", "revert"}
+    test>TYPES: set[str] = {"fix", "hotfix", "feat", "docs", "style", "refactor", "test", "chore", "revert"}
     test>SCOPES: set[str] = {"deps", "ci/cd", "packaging", "python", "git"}
     test>SCOPE_REQUIRED: bool = True
     test>new stuff...


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- support multiline commit messages by validating the first line as the conventional-commit subject
- support breaking-change `!` markers before the colon, including scoped forms like `feat(api)!: ...`
- add `hotfix` to the default allowed commit types
- bump `VERSION` from `0.3.0` to `0.4.0` for the new validation features
- document the inline unit test command in the README as `pytest commit-msg.py`
- repair stale inline test assumptions so the documented test command passes

## Testing
- `python3 -m py_compile commit-msg.py`
- `pytest commit-msg.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aeb9f2ff-d470-4aa8-9a0c-e7ce96fb0bfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aeb9f2ff-d470-4aa8-9a0c-e7ce96fb0bfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

